### PR TITLE
Treat each update individually, not as a CSV upload.

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -69,7 +69,6 @@ module SalesforceBulkApi
 
     def add_batches
       raise 'Records must be an array of hashes.' unless @records.is_a? Array
-      keys = @records.reduce({}) {|h, pairs| pairs.each {|k, v| (h[k] ||= []) << v}; h}.keys
 
       @records_dup = @records.clone
 
@@ -80,14 +79,14 @@ module SalesforceBulkApi
       super_records << @records_dup unless @records_dup.empty?
 
       super_records.each do |batch|
-        @batch_ids << add_batch(keys, batch)
+        @batch_ids << add_batch(batch)
       end
     end
 
-    def add_batch(keys, batch)
+    def add_batch(batch)
       xml = "#{@XML_HEADER}<sObjects xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
       batch.each do |r|
-        xml += create_sobject(keys, r)
+        xml += create_sobject(r)
       end
       xml += '</sObjects>'
       path = "job/#{@job_id}/batch/"
@@ -109,9 +108,9 @@ module SalesforceBulkApi
       xml += '</sObject>'
     end
 
-    def create_sobject(keys, r)
+    def create_sobject(r)
       sobject_xml = '<sObject>'
-      keys.each do |k|
+      r.keys.each do |k|
         if r[k].is_a?(Hash)
           sobject_xml += "<#{k}>"
           sobject_xml += build_sobject(r[k])

--- a/lib/salesforce_bulk_api/version.rb
+++ b/lib/salesforce_bulk_api/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulkApi
-  VERSION = '0.0.12'
+  VERSION = '0.0.12.1'
 end

--- a/lib/salesforce_bulk_api/version.rb
+++ b/lib/salesforce_bulk_api/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulkApi
-  VERSION = '0.0.12.1'
+  VERSION = '0.1.0'
 end


### PR DESCRIPTION
As far as I can tell, the concept of the bulk API is a CSV file upload.

That is you have a set of columns and a set of rows with values set.

With this concept, if a value isn't set, then you have a choice of setting it to nil or ignoring it. The set nil boolean switches between these two choices.

We aren't using the system this way. We don't want fields that we don't set to be set to nil, and we do want fields that we set to be set to nil.

Of the two ways I had to address this, I chose the simpler path. For any single record, ignore the other records, and just simply send all of the values in that record.

The alternative would be to send nil for any value that is actually set for a record, and if the boolean is set, send nil for all unspecified values. This feels more in the spirit of the code as it exists now.